### PR TITLE
Update autosequence.ino

### DIFF
--- a/static_test_driver/autosequence.ino
+++ b/static_test_driver/autosequence.ino
@@ -40,7 +40,8 @@ typedef enum {
   MAINSTAGE,
   OXYGEN_SHUTDOWN,
   SHUTDOWN,
-  COOL_DOWN
+  COOL_DOWN,
+  STATIC_TEST_COMPLETE
 } state_t;
 
 // Convenience
@@ -48,7 +49,7 @@ typedef enum {
     state = STATE;            \
     write_state(#STATE);      \
   }
-  
+
 
 long start_time = 0;
 long shutdown_time = 0;
@@ -82,7 +83,7 @@ void start_countdown() {
   if (valve_status[FUEL_PRE] ||
       valve_status[FUEL_MAIN] ||
       valve_status[OX_PRE] ||
-      valve_status[OX_MAIN]) {
+      valve_status[OX_MAIN] ||) {
     Serial.println(F("Countdown aborted due to unexpected initial state"));
     SET_STATE(STAND_BY) // Set state to signal countdown was aborted
   }
@@ -105,18 +106,21 @@ void abort_autosequence() {
     case PRESTAGE_READY:
       set_valve(FUEL_PRE, 0);
       set_valve(OX_PRE, 0);
+      set_valve(N2_CHOKE. 0);   
       SET_STATE(STAND_BY)
       break;
 
     case PRESTAGE:
+      set_valve(N2_CHOKE, 0);   
       set_valve(OX_PRE, 0);
       set_valve(FUEL_PRE, 0);
       reset_igniter();
       SET_STATE(COOL_DOWN)
       shutdown_time = millis();
       break;
-    
+
     case MAINSTAGE:
+      set_valve(N2_CHOKE, 0); 
       set_valve(OX_PRE, 0);
       set_valve(FUEL_PRE, 0);
       SET_STATE(SHUTDOWN)
@@ -156,6 +160,7 @@ void run_control() {
       #endif
       if (run_time >= PRESTAGE_PREP_TIME) {
         SET_STATE(PRESTAGE_READY)
+        set_valve(N2_CHOKE, 1);               
         set_valve(FUEL_PRE, 1);
         set_valve(OX_PRE, 1);
       }
@@ -214,6 +219,7 @@ void run_control() {
     case SHUTDOWN:
       // Both prestage valves are closed, others may still be open
       if (millis() >= shutdown_time + PRE_LEADTIME) {
+        set_valve(N2_CHOKE, 0);   
         set_valve(OX_MAIN, 0);
         set_valve(FUEL_MAIN, 0);
         SET_STATE(COOL_DOWN)
@@ -226,6 +232,38 @@ void run_control() {
         Serial.println(F("Run finished"));
         SET_STATE(STAND_BY)
         start_time = 0;
+      }
+      break;
+
+    case STATIC_TEST_COMPLETE:
+      // State that requires manual input to open Kero valve once static test is completed for the day
+      char state;
+      for (int i=1; i<10; i++){
+        cout << "Are you done test firing for the day? [Y/N]";
+        cin >> state;
+        if (state=='Y'){
+          cout << "Are you sure you're done? [Y/N]";
+          cin >> state;
+          if (state=='Y'){
+            cout << "Draining Kerosene valve...vwooosh";
+            set_valve(KERO_DRAIN, 1);
+            return;
+          }
+          else if (state=='N'){
+            cout << "Let the firing resume!";
+            return;
+          }
+          else{
+            break;
+          }
+        }
+        else if (state=='N'){
+          cout << "Let the firing resume!";
+          return;
+        }
+        else{
+          break;
+        }
       }
       break;
   }


### PR DESCRIPTION
abort_autosequence (cases: prestage_ready / prestage / mainstage) set N2_CHOKE as closed case TERMINAL_COUNT: pressurize fuel by opening N2_CHOKE case SHUTDOWN: close N2
Also added user defined input case STATIC_TEST_COMPLETE of which prompts the user if they want to open the Kerosene drain valve,  this is a case specific function, so for each shutdown you will have the option to open the kerosene drain allowing for safer disassembly.